### PR TITLE
[TSK-80] docker-composeにredisを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
   test-db-store:
     driver: local
 
-services: 
+services:
   # データベース
   db:
     image: mysql:latest
@@ -22,7 +22,7 @@ services:
       TZ: Asia/Tokyo
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     command: --collation-server=utf8mb4_general_ci
-  
+
   # テスト用データベース
   test_db:
     image: mysql:latest
@@ -40,12 +40,18 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     command: --collation-server=utf8mb4_general_ci
 
+  # redis
+  redis:
+    image: redis:6.0-alpine3.18
+    ports:
+      - 6380:6379
+
   # バックエンドサーバー
   app:
     build:
       context: .
       dockerfile: ./ops/docker/app/Dockerfile
-    tty: true 
+    tty: true
     ports:
       - "8080:8080"
     volumes:
@@ -56,6 +62,7 @@ services:
     depends_on:
       - db
       - test_db
+      - redis
     environment:
       MYSQL_DATABASE: code_kakitai
       DB_HOST: db


### PR DESCRIPTION
# 内容
docker-composeにredisを追加



# 動作確認
コンテナの起動を確認

```
$ docker-compose ps

NAME                     IMAGE                  COMMAND                  SERVICE             CREATED             STATUS              PORTS
code-kakitai-app-1       code-kakitai-app       "bash"                   app                 56 seconds ago      Up 4 seconds        
code-kakitai-db-1        mysql:latest           "docker-entrypoint.s…"   db                  5 days ago          Up 54 seconds       0.0.0.0:3306->3306/tcp, 33060/tcp
code-kakitai-redis-1     redis:6.0-alpine3.18   "docker-entrypoint.s…"   redis               56 seconds ago      Up 4 seconds        0.0.0.0:6380->6379/tcp
code-kakitai-test_db-1   mysql:latest           "docker-entrypoint.s…"   test_db             56 seconds ago      Up 4 seconds        33060/tcp, 0.0.0.0:3307->3306/tcp
```