### PR TITLE
presentationのerrorハンドリング修正

### DIFF
--- a/app/presentation/cart/handler.go
+++ b/app/presentation/cart/handler.go
@@ -42,7 +42,7 @@ func (h handler) PostCart(ctx *gin.Context) {
 		ctx.Request.Context(),
 		dto,
 	); err != nil {
-		settings.ReturnStatusInternalServerError(ctx, err)
+		settings.ReturnError(ctx, err)
 	}
 	settings.ReturnStatusNoContent(ctx)
 }

--- a/app/presentation/order/handler.go
+++ b/app/presentation/order/handler.go
@@ -32,6 +32,7 @@ func (h handler) PostOrders(ctx *gin.Context) {
 	// TODO リクエストのバリデーション
 	err := ctx.ShouldBindJSON(&params)
 	if err != nil {
+		// todo 422エラーの方が良いかも？
 		settings.ReturnBadRequest(ctx, err)
 	}
 	// todo userIDはsession等で別途取得する

--- a/app/presentation/products/handler.go
+++ b/app/presentation/products/handler.go
@@ -3,6 +3,7 @@ package products
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+
 	"github/code-kakitai/code-kakitai/application/product"
 	"github/code-kakitai/code-kakitai/presentation/settings"
 )
@@ -60,7 +61,7 @@ func (h handler) PostProducts(ctx *gin.Context) {
 
 	dto, err := h.saveProductUseCase.Run(ctx, input)
 	if err != nil {
-		settings.ReturnStatusInternalServerError(ctx, err)
+		settings.ReturnError(ctx, err)
 	}
 	response := postProductResponse{
 		productResponseModel{
@@ -85,7 +86,7 @@ func (h handler) PostProducts(ctx *gin.Context) {
 func (h handler) GetProducts(ctx *gin.Context) {
 	dtos, err := h.fetchProductUseCase.Run(ctx)
 	if err != nil {
-		settings.ReturnStatusInternalServerError(ctx, err)
+		settings.ReturnError(ctx, err)
 	}
 
 	var products []getProductsResponse

--- a/app/presentation/settings/gin.go
+++ b/app/presentation/settings/gin.go
@@ -64,6 +64,10 @@ func ReturnStatusInternalServerError(ctx *gin.Context, err error) {
 	returnAbortWith(ctx, http.StatusInternalServerError, err)
 }
 
+func ReturnError(ctx *gin.Context, err error) {
+	ctx.Error(err)
+}
+
 func returnAbortWith(ctx *gin.Context, code int, err error) {
 	var msg string
 	if err != nil {

--- a/app/presentation/settings/middleware.go
+++ b/app/presentation/settings/middleware.go
@@ -1,0 +1,21 @@
+package settings
+
+import (
+	"github.com/gin-gonic/gin"
+
+	errDomain "github/code-kakitai/code-kakitai/domain/error"
+)
+
+func ErrorHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		for _, err := range c.Errors {
+			switch e := err.Err.(type) {
+			case *errDomain.Error:
+				ReturnStatusBadRequest(c, e)
+			default:
+				ReturnStatusInternalServerError(c, e)
+			}
+		}
+	}
+}

--- a/app/server/route/route.go
+++ b/app/server/route/route.go
@@ -15,10 +15,12 @@ import (
 	health_handler "github/code-kakitai/code-kakitai/presentation/health_handler"
 	orderPre "github/code-kakitai/code-kakitai/presentation/order"
 	productPre "github/code-kakitai/code-kakitai/presentation/products"
+	"github/code-kakitai/code-kakitai/presentation/settings"
 	userPre "github/code-kakitai/code-kakitai/presentation/user"
 )
 
 func InitRoute(api *ginpkg.Engine) {
+	api.Use(settings.ErrorHandler())
 	v1 := api.Group("/v1")
 	v1.GET("/health", health_handler.HealthCheck)
 


### PR DESCRIPTION
## 内容
- presentationにてdomainで定義したエラーを400で返し、それ以外を5xxで返すように修正しました

## 実装
- middlewareを定義しそこでエラーの型によって判別するようにしています。
※ginの理解が浅いため、[こちらの記事](https://spdeepak.hashnode.dev/golang-gin-tutorial-5)を見ながら実装しました