### PR TITLE
空のshopのusecaseを削除

### DIFF
--- a/app/application/shop/shop_use_case.go
+++ b/app/application/shop/shop_use_case.go
@@ -1,1 +1,0 @@
-package shop


### PR DESCRIPTION
空で何も定義されていないため、shopのusecaseを削除