### PR TITLE
settingsをpresenterに変更

### DIFF
--- a/app/presentation/cart/handler.go
+++ b/app/presentation/cart/handler.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	cartApp "github/code-kakitai/code-kakitai/application/cart"
-	"github/code-kakitai/code-kakitai/presentation/settings"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
 )
 
 type handler struct {
@@ -28,7 +28,7 @@ func (h handler) PostCart(ctx *gin.Context) {
 	var param PostCartsParams
 	// TODO リクエストのバリデーション
 	if err := ctx.ShouldBindJSON(&param); err != nil {
-		settings.ReturnBadRequest(ctx, err)
+		presenter.ReturnBadRequest(ctx, err)
 	}
 
 	// todo userIDはsession等で別途取得する
@@ -42,7 +42,7 @@ func (h handler) PostCart(ctx *gin.Context) {
 		ctx.Request.Context(),
 		dto,
 	); err != nil {
-		settings.ReturnError(ctx, err)
+		presenter.ReturnError(ctx, err)
 	}
-	settings.ReturnStatusNoContent(ctx)
+	presenter.ReturnStatusNoContent(ctx)
 }

--- a/app/presentation/health_handler/handler.go
+++ b/app/presentation/health_handler/handler.go
@@ -1,7 +1,7 @@
 package health_handler
 
 import (
-	"github/code-kakitai/code-kakitai/presentation/settings"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
 
 	"github.com/gin-gonic/gin"
 )
@@ -18,5 +18,5 @@ func HealthCheck(ctx *gin.Context) {
 	res := HealthResponse{
 		Status: "ok",
 	}
-	settings.ReturnStatusOK(ctx, res)
+	presenter.ReturnStatusOK(ctx, res)
 }

--- a/app/presentation/order/handler.go
+++ b/app/presentation/order/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	orderApp "github/code-kakitai/code-kakitai/application/order"
-	"github/code-kakitai/code-kakitai/presentation/settings"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
 )
 
 type handler struct {
@@ -32,7 +32,7 @@ func (h handler) PostOrders(ctx *gin.Context) {
 	// TODO リクエストのバリデーション
 	err := ctx.ShouldBindJSON(&params)
 	if err != nil {
-		settings.ReturnBadRequest(ctx, err)
+		presenter.ReturnBadRequest(ctx, err)
 	}
 	// todo userIDはsession等で別途取得する
 	userID := "test_user_id"
@@ -50,8 +50,8 @@ func (h handler) PostOrders(ctx *gin.Context) {
 		time.Now(),
 	)
 	if err != nil {
-		settings.ReturnStatusInternalServerError(ctx, err)
+		presenter.ReturnStatusInternalServerError(ctx, err)
 	}
 
-	settings.ReturnStatusCreated(ctx, id)
+	presenter.ReturnStatusCreated(ctx, id)
 }

--- a/app/presentation/presenter/gin.go
+++ b/app/presentation/presenter/gin.go
@@ -1,4 +1,4 @@
-package settings
+package presenter
 
 import (
 	"net/http"

--- a/app/presentation/presenter/middleware.go
+++ b/app/presentation/presenter/middleware.go
@@ -1,4 +1,4 @@
-package settings
+package presenter
 
 import (
 	"github.com/gin-gonic/gin"

--- a/app/presentation/products/handler.go
+++ b/app/presentation/products/handler.go
@@ -1,10 +1,11 @@
 package products
 
 import (
+	"github/code-kakitai/code-kakitai/application/product"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
+
 	validator "github.com/code-kakitai/go-pkg/validator"
 	"github.com/gin-gonic/gin"
-	"github/code-kakitai/code-kakitai/application/product"
-	"github/code-kakitai/code-kakitai/presentation/settings"
 )
 
 type handler struct {
@@ -42,12 +43,12 @@ func (h handler) PostProducts(ctx *gin.Context) {
 	var params PostProductsParams
 	err := ctx.ShouldBindJSON(&params)
 	if err != nil {
-		settings.ReturnBadRequest(ctx, err)
+		presenter.ReturnBadRequest(ctx, err)
 	}
 	validate := validator.GetValidator()
 	err = validate.Struct(params)
 	if err != nil {
-		settings.ReturnStatusBadRequest(ctx, err)
+		presenter.ReturnStatusBadRequest(ctx, err)
 	}
 
 	input := product.SaveProductUseCaseInputDto{
@@ -60,7 +61,7 @@ func (h handler) PostProducts(ctx *gin.Context) {
 
 	dto, err := h.saveProductUseCase.Run(ctx, input)
 	if err != nil {
-		settings.ReturnError(ctx, err)
+		presenter.ReturnError(ctx, err)
 	}
 	response := postProductResponse{
 		productResponseModel{
@@ -72,7 +73,7 @@ func (h handler) PostProducts(ctx *gin.Context) {
 			Stock:       dto.Stock,
 		},
 	}
-	settings.ReturnStatusCreated(ctx, response)
+	presenter.ReturnStatusCreated(ctx, response)
 }
 
 // GetProducts godoc
@@ -85,7 +86,7 @@ func (h handler) PostProducts(ctx *gin.Context) {
 func (h handler) GetProducts(ctx *gin.Context) {
 	dtos, err := h.fetchProductUseCase.Run(ctx)
 	if err != nil {
-		settings.ReturnError(ctx, err)
+		presenter.ReturnError(ctx, err)
 	}
 
 	var products []getProductsResponse
@@ -102,5 +103,5 @@ func (h handler) GetProducts(ctx *gin.Context) {
 		})
 	}
 
-	settings.ReturnStatusCreated(ctx, products)
+	presenter.ReturnStatusCreated(ctx, products)
 }

--- a/app/presentation/user/handler.go
+++ b/app/presentation/user/handler.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	userApp "github/code-kakitai/code-kakitai/application/user"
-	"github/code-kakitai/code-kakitai/presentation/settings"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
 )
 
 type handler struct {
@@ -34,7 +34,7 @@ func (h handler) GetUserByID(ctx *gin.Context) {
 	id := ctx.Param("id")
 	dto, err := h.findUserUseCase.Run(ctx, id)
 	if err != nil {
-		settings.ReturnNotFound(ctx, err)
+		presenter.ReturnNotFound(ctx, err)
 	}
 	res := getUserResponse{
 		User: userResponseModel{
@@ -46,5 +46,5 @@ func (h handler) GetUserByID(ctx *gin.Context) {
 			Address:     dto.Address,
 		},
 	}
-	settings.ReturnStatusOK(ctx, res)
+	presenter.ReturnStatusOK(ctx, res)
 }

--- a/app/server/route/route.go
+++ b/app/server/route/route.go
@@ -14,13 +14,13 @@ import (
 	cartPre "github/code-kakitai/code-kakitai/presentation/cart"
 	health_handler "github/code-kakitai/code-kakitai/presentation/health_handler"
 	orderPre "github/code-kakitai/code-kakitai/presentation/order"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
 	productPre "github/code-kakitai/code-kakitai/presentation/products"
-	"github/code-kakitai/code-kakitai/presentation/settings"
 	userPre "github/code-kakitai/code-kakitai/presentation/user"
 )
 
 func InitRoute(api *ginpkg.Engine) {
-	api.Use(settings.ErrorHandler())
+	api.Use(presenter.ErrorHandler())
 	v1 := api.Group("/v1")
 	v1.GET("/health", health_handler.HealthCheck)
 

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github/code-kakitai/code-kakitai/config"
-	"github/code-kakitai/code-kakitai/presentation/settings"
+	"github/code-kakitai/code-kakitai/presentation/presenter"
 	"github/code-kakitai/code-kakitai/server/route"
 )
 
 func Run(ctx context.Context, conf *config.Config) {
-	api := settings.NewGinEngine()
+	api := presenter.NewGinEngine()
 	route.InitRoute(api)
 
 	address := conf.Server.Address + ":" + conf.Server.Port


### PR DESCRIPTION
あくまで提案ベースなのですが、
settingsをpresenterに命名を変更しました。


## 目的

クリーンアーキテクチャのpresenterの役割を持つと直感的に伝えるため。
→ 図で表現しようと考えた時に、settingsと表記すると違和感があること。
→ 書籍的にも説明がしやすいかなと。


## テスト

テストの通過を確認。

````
$ make test
docker compose exec app sh -c "go vet ./..."
go: downloading go.uber.org/multierr v1.11.0
go: downloading github.com/go-playground/validator/v10 v10.15.4
cd app && go test ./...
?       github/code-kakitai/code-kakitai/application/cart       [no test files]
?       github/code-kakitai/code-kakitai/application/notification       [no test files]
?       github/code-kakitai/code-kakitai/application/owner      [no test files]
?       github/code-kakitai/code-kakitai/application/product    [no test files]
?       github/code-kakitai/code-kakitai/application/shop       [no test files]
?       github/code-kakitai/code-kakitai/application/transaction        [no test files]
?       github/code-kakitai/code-kakitai/application/user       [no test files]
ok      github/code-kakitai/code-kakitai/application/order      0.324s
?       github/code-kakitai/code-kakitai/cli    [no test files]
?       github/code-kakitai/code-kakitai/cmd    [no test files]
?       github/code-kakitai/code-kakitai/config [no test files]
?       github/code-kakitai/code-kakitai/docs/swagger   [no test files]
?       github/code-kakitai/code-kakitai/domain/error   [no test files]
?       github/code-kakitai/code-kakitai/domain/cart    [no test files]
?       github/code-kakitai/code-kakitai/infrastructure/mysql/db        [no test files]
ok      github/code-kakitai/code-kakitai/domain/order   0.446s
ok      github/code-kakitai/code-kakitai/domain/owner   0.260s
ok      github/code-kakitai/code-kakitai/domain/product 0.638s
ok      github/code-kakitai/code-kakitai/domain/shop    0.841s
?       github/code-kakitai/code-kakitai/infrastructure/mysql/db/db_test        [no test files]
?       github/code-kakitai/code-kakitai/infrastructure/mysql/db/dbgen  [no test files]
?       github/code-kakitai/code-kakitai/infrastructure/mysql/db/schema [no test files]
ok      github/code-kakitai/code-kakitai/domain/user    1.022s
?       github/code-kakitai/code-kakitai/infrastructure/redis   [no test files]
?       github/code-kakitai/code-kakitai/presentation/cart      [no test files]
?       github/code-kakitai/code-kakitai/presentation/health_handler    [no test files]
?       github/code-kakitai/code-kakitai/server/route   [no test files]
?       github/code-kakitai/code-kakitai/presentation/presenter [no test files]
?       github/code-kakitai/code-kakitai/server [no test files]
?       github/code-kakitai/code-kakitai/presentation/user      [no test files]
?       github/code-kakitai/code-kakitai/presentation/order     [no test files]
?       github/code-kakitai/code-kakitai/presentation/products  [no test files]
ok      github/code-kakitai/code-kakitai/infrastructure/mysql/query_service     11.184s
ok      github/code-kakitai/code-kakitai/infrastructure/mysql/repository        11.254s
ok      github/code-kakitai/code-kakitai/infrastructure/redis/repository        0.662s [no tests to run]
```
