### PR TITLE
goのバージョン更新漏れを対応

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -1,6 +1,6 @@
 module github/code-kakitai/code-kakitai
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/alicebob/miniredis v2.5.0+incompatible

--- a/app/infrastructure/mysql/repository/user_repository_test.go
+++ b/app/infrastructure/mysql/repository/user_repository_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestUserRepository_FindById(t *testing.T) {
-	user, _ := userDomain.Reconstruct("1", "example@test.com", "08011112222", "太郎", "田中", "東京都", "渋谷区", "1-1-1")
+	user, _ := userDomain.Reconstruct("01HCNYK0PKYZWB0ZT1KR0EPWGP", "example@test.com", "08011112222", "太郎", "田中", "東京都", "渋谷区", "1-1-1")
 	tests := []struct {
 		name string
 		want *userDomain.User
@@ -27,7 +27,7 @@ func TestUserRepository_FindById(t *testing.T) {
 	resetTestData(t)
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf(": %s", tt.name), func(t *testing.T) {
-			got, err := userRepository.FindById(ctx, "1")
+			got, err := userRepository.FindById(ctx, "01HCNYK0PKYZWB0ZT1KR0EPWGP")
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/code-kakitai/go-pkg
 
-go 1.20
+go 1.21.0
 
 require (
 	github.com/go-playground/validator/v10 v10.15.4

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=


### PR DESCRIPTION
- pkg/go.modのバージョンを更新
- Goのtoolchainを利用しないように、1.21.0に明示的に修正
- テストのエラーに対応