### PR TITLE
update/ciの操作をcontainer起動の有無で変えるようにした

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,5 @@ jobs:
 
       - name: test
         run: |
-          cd app && go vet ./... && go test ./...
+          make test
 


### PR DESCRIPTION
- localでテスト回す時はdockerで、CI環境ではローカルでtest回るようにしました
※CI環境でdocker使うと、コンテナの起動に時間かかるので、CI環境はコンテナで回さないようにしています