### PR TITLE
update/not_found_errorをerrorDomainにカプセル化しました

### DIFF
--- a/app/presentation/settings/middleware.go
+++ b/app/presentation/settings/middleware.go
@@ -1,6 +1,8 @@
 package settings
 
 import (
+	"errors"
+
 	"github.com/gin-gonic/gin"
 
 	errDomain "github/code-kakitai/code-kakitai/domain/error"
@@ -12,6 +14,9 @@ func ErrorHandler() gin.HandlerFunc {
 		for _, err := range c.Errors {
 			switch e := err.Err.(type) {
 			case *errDomain.Error:
+				if errors.Is(err, errDomain.NotFoundErr) {
+					ReturnNotFound(c, e)
+				}
 				ReturnStatusBadRequest(c, e)
 			default:
 				ReturnStatusInternalServerError(c, e)

--- a/app/presentation/user/handler.go
+++ b/app/presentation/user/handler.go
@@ -34,7 +34,7 @@ func (h handler) GetUserByID(ctx *gin.Context) {
 	id := ctx.Param("id")
 	dto, err := h.findUserUseCase.Run(ctx, id)
 	if err != nil {
-		settings.ReturnNotFound(ctx, err)
+		settings.ReturnError(ctx, err)
 	}
 	res := getUserResponse{
 		User: userResponseModel{


### PR DESCRIPTION
- error.goに IsNotFoundErr関数をもたせることで、エラーの知識をerror.goに集約しました（handler.go等はerrorsパッケージをimportする必要がなくなった）