### PR TITLE
NotFoundErrをdomain/errorに修正

### DIFF
--- a/app/domain/error/error.go
+++ b/app/domain/error/error.go
@@ -1,7 +1,5 @@
 package error
 
-import "errors"
-
 type Error struct {
 	description string
 }
@@ -16,4 +14,4 @@ func NewError(s string) *Error {
 	}
 }
 
-var NotFoundErr = errors.New("not found")
+var NotFoundErr = NewError("not found")


### PR DESCRIPTION
`NotFoundErr`は`errDomain.Error`である必要があるように見えるのですが、認識あってますか？


https://github.com/code-kakitai/code-kakitai/blob/398959a6ad41fa3266b8ee921869eb69fdb6581d/app/presentation/settings/middleware.go#L16-L17

