### PR TITLE
Integrationテストの実装

### DIFF
--- a/app/infrastructure/mysql/db/db_test/container.go
+++ b/app/infrastructure/mysql/db/db_test/container.go
@@ -83,9 +83,9 @@ func ConnectDB(resource *dockertest.Resource, pool *dockertest.Pool) *sql.DB {
 	return db
 }
 
-func SetupTestDB() {
+func SetupTestDB(schemaFilePath string) {
 	// マイグレーション
-	desiredDDLs, err := sqldef.ReadFile("../db/schema/schema.sql")
+	desiredDDLs, err := sqldef.ReadFile(schemaFilePath)
 	if err != nil {
 		log.Fatalf("failed to read schema file: %s", err)
 	}

--- a/app/infrastructure/mysql/repository/common_test.go
+++ b/app/infrastructure/mysql/repository/common_test.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/testfixtures.v2"
 
 	"github/code-kakitai/code-kakitai/infrastructure/mysql/db"
-	"github/code-kakitai/code-kakitai/infrastructure/mysql/db/db_test"
+	dbTest "github/code-kakitai/code-kakitai/infrastructure/mysql/db/db_test"
 	"github/code-kakitai/code-kakitai/infrastructure/mysql/db/dbgen"
 )
 
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	defer dbCon.Close()
 
 	// テスト用DBをセットアップ
-	dbTest.SetupTestDB()
+	dbTest.SetupTestDB("../db/schema/schema.sql")
 
 	// テストデータの準備
 	fixturePath := "../fixtures"

--- a/app/server/api_test/main_test.go
+++ b/app/server/api_test/main_test.go
@@ -20,13 +20,18 @@ var (
 func TestMain(m *testing.M) {
 	var err error
 
+	// DBの立ち上げ
 	resource, pool := dbTest.CreateContainer()
 	defer dbTest.CloseContainer(resource, pool)
 
+	// DBへ接続する
 	dbCon := dbTest.ConnectDB(resource, pool)
 	defer dbCon.Close()
 
+	// テスト用DBをセットアップ
 	dbTest.SetupTestDB("../../infrastructure/mysql/db/schema/schema.sql")
+
+	// テストデータの準備
 	fixtures, err = testfixtures.NewFolder(
 		dbCon,
 		&testfixtures.MySQL{},

--- a/app/server/api_test/main_test.go
+++ b/app/server/api_test/main_test.go
@@ -8,11 +8,13 @@ import (
 	"github/code-kakitai/code-kakitai/server/route"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"gopkg.in/testfixtures.v2"
 )
 
 var (
 	fixtures *testfixtures.Context
+	api      *gin.Engine
 )
 
 func TestMain(m *testing.M) {
@@ -38,8 +40,15 @@ func TestMain(m *testing.M) {
 	db.SetReadQuery(q)
 	db.SetDB(dbCon)
 
-	api := settings.NewGinEngine()
+	api = settings.NewGinEngine()
 	route.InitRoute(api)
 
 	m.Run()
+}
+
+func resetTestData(t *testing.T) {
+	t.Helper()
+	if err := fixtures.Load(); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/app/server/api_test/main_test.go
+++ b/app/server/api_test/main_test.go
@@ -1,13 +1,14 @@
-package query_service
+package api_test
 
 import (
-	"testing"
-
-	"gopkg.in/testfixtures.v2"
-
 	"github/code-kakitai/code-kakitai/infrastructure/mysql/db"
 	dbTest "github/code-kakitai/code-kakitai/infrastructure/mysql/db/db_test"
 	"github/code-kakitai/code-kakitai/infrastructure/mysql/db/dbgen"
+	"github/code-kakitai/code-kakitai/presentation/settings"
+	"github/code-kakitai/code-kakitai/server/route"
+	"testing"
+
+	"gopkg.in/testfixtures.v2"
 )
 
 var (
@@ -17,20 +18,18 @@ var (
 func TestMain(m *testing.M) {
 	var err error
 
-	// DBの立ち上げ
 	resource, pool := dbTest.CreateContainer()
 	defer dbTest.CloseContainer(resource, pool)
 
-	// DBへ接続する
 	dbCon := dbTest.ConnectDB(resource, pool)
 	defer dbCon.Close()
 
-	// テスト用DBをセットアップ
-	dbTest.SetupTestDB("../db/schema/schema.sql")
-
-	// テストデータの準備
-	fixturePath := "../fixtures"
-	fixtures, err = testfixtures.NewFolder(dbCon, &testfixtures.MySQL{}, fixturePath)
+	dbTest.SetupTestDB("../../infrastructure/mysql/db/schema/schema.sql")
+	fixtures, err = testfixtures.NewFolder(
+		dbCon,
+		&testfixtures.MySQL{},
+		"../../infrastructure/mysql/fixtures",
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -39,13 +38,8 @@ func TestMain(m *testing.M) {
 	db.SetReadQuery(q)
 	db.SetDB(dbCon)
 
-	// テスト実行
-	m.Run()
-}
+	api := settings.NewGinEngine()
+	route.InitRoute(api)
 
-func resetTestData(t *testing.T) {
-	t.Helper()
-	if err := fixtures.Load(); err != nil {
-		t.Fatal(err)
-	}
+	m.Run()
 }

--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestProduct_GetProducts(t *testing.T) {
-	// GET処理の場合は、DBの読み込みのテストケースのため、冒頭でのみテストデータを初期化する
+	// GET処理なので、冒頭でのみテストデータを初期化する
 	// 書き込み処理の場合は、テストケースごとに初期化する
 	resetTestData(t)
 
@@ -40,32 +40,20 @@ func TestProduct_GetProducts(t *testing.T) {
 			w := httptest.NewRecorder()
 			api.ServeHTTP(w, req)
 
-			testfunc := func(w *httptest.ResponseRecorder) bool {
-				// ステータスコードが期待値と比較
-				if w.Code != tt.expectedCode {
-					t.Errorf("expected status code %d, got %d", tt.expectedCode, w.Code)
-					// ステータスが異なる場合は以降の比較を行わない
-					return false
-				}
-
-				// レスポンスボディのパース
-				var actualBody []map[string]interface{}
-				if err := json.Unmarshal(w.Body.Bytes(), &actualBody); err != nil {
-					t.Errorf("failed to unmarshal response body: %v", err)
-					// パースに失敗した場合は以降の比較を行わない
-					return false
-				}
-
-				// レスポンスボディが期待値と比較
-				if diff := cmp.Diff(tt.expectedBody, actualBody); diff != "" {
-					t.Errorf("response body mismatch (-want +got):\n%s", diff)
-				}
-
-				return true
+			// ステータスコードの期待値と比較
+			if w.Code != tt.expectedCode {
+				t.Errorf("expected status code %d, got %d", tt.expectedCode, w.Code)
 			}
 
-			if !testfunc(w) {
-				t.Fail()
+			// レスポンスボディのパース
+			var responseBody []map[string]interface{}
+			if err := json.Unmarshal(w.Body.Bytes(), &responseBody); err != nil {
+				t.Fatalf("failed to unmarshal response body: %v", err)
+			}
+
+			// レスポンスボディの期待値と比較
+			if diff := cmp.Diff(tt.expectedBody, responseBody); diff != "" {
+				t.Errorf("response body mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -41,7 +41,7 @@ func TestProduct_GetProducts(t *testing.T) {
 			api.ServeHTTP(w, req)
 
 			testfunc := func(w *httptest.ResponseRecorder) bool {
-				// ステータスコードが期待値通りか比較
+				// ステータスコードが期待値と比較
 				if w.Code != tt.expectedCode {
 					t.Errorf("expected status code %d, got %d", tt.expectedCode, w.Code)
 					// ステータスが異なる場合は以降の比較を行わない
@@ -56,7 +56,7 @@ func TestProduct_GetProducts(t *testing.T) {
 					return false
 				}
 
-				// レスポンスボディが期待値通りか比較
+				// レスポンスボディが期待値と比較
 				if diff := cmp.Diff(tt.expectedBody, actualBody); diff != "" {
 					t.Errorf("response body mismatch (-want +got):\n%s", diff)
 				}

--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -1,0 +1,65 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestProduct_GetProducts(t *testing.T) {
+	tests := map[string]struct {
+		expectedCode int
+		expectedBody []map[string]any
+	}{
+		"正常系": {
+			expectedCode: http.StatusOK,
+			expectedBody: []map[string]any{
+				{
+					"description": "",
+					"id":          "01HCNYK4MQNC6G6X3F3DGXZ2J8",
+					"name":        "サウナハット",
+					"price":       float64(3000),
+					"stock":       float64(20),
+					"owner_id":    "01HCNYK3F7RJTWJ7GAQHPZDVE3",
+					"owner_name":  "古戸垣敦",
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetTestData(t)
+			req := httptest.NewRequest(http.MethodGet, "/v1/products", nil)
+
+			w := httptest.NewRecorder()
+			api.ServeHTTP(w, req)
+
+			f := func(w *httptest.ResponseRecorder) bool {
+				if w.Code != tt.expectedCode {
+					t.Errorf("expected status code %d, got %d", tt.expectedCode, w.Code)
+					// ステータスが異なる場合は以降の比較を行わない
+					return false
+				}
+
+				var actualBody []map[string]interface{}
+				if err := json.Unmarshal(w.Body.Bytes(), &actualBody); err != nil {
+					t.Errorf("failed to unmarshal response body: %v", err)
+					return false
+				}
+				if diff := cmp.Diff(tt.expectedBody, actualBody); diff != "" {
+					t.Errorf("response body mismatch (-want +got):\n%s", diff)
+				}
+
+				return true
+			}
+
+			if !f(w) {
+				t.Fail()
+			}
+		})
+	}
+}


### PR DESCRIPTION
# 内容
Integrationテストが実行可能にした。

# エビデンス

実行方法
```
$ cd app/server/api_test
$ go test
```

実行結果
```
PASS
ok      github/code-kakitai/code-kakitai/server/api_test        7.581s
```

# 備考欄

## テストの記述箇所について
ルーティングがまとまっている、serverディレクトリ配下にテストを記述しています。
presentation配下でテスト記述を行いたい場合は、別のブランチにて移行をお願いいたします。

## POSTの例
POSTの例は下記のプルリクで対応しています。ただし、repository配下にてpanicが発生するため、Draftにしています。
https://github.com/code-kakitai/code-kakitai/pull/103

## テスト処理の共通化について

下記の箇所は関数にして共通化が可能ですが、あえてわかりやすくするために、素のまま書いています

```
w := httptest.NewRecorder()
api.ServeHTTP(w, req)
```