### PR TITLE
ProductPostsの統合テスト

### DIFF
--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -115,7 +115,7 @@ func TestProduct_PostProducts(t *testing.T) {
 			if !ok {
 				t.Fatalf("failed to parse response body: %v", actualBody)
 			}
-			// UUIDはランダムな文字列なため、形式のみチェック
+			// ULIDはランダムな文字列なため、形式のみチェック
 			if _, err := ulid.ParseStrict(product["id"].(string)); err != nil {
 				t.Errorf("id is not a valid ULID: %v", product["id"])
 			}

--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +35,73 @@ func TestProduct_GetProducts(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resetTestData(t)
 			req := httptest.NewRequest(http.MethodGet, "/v1/products", nil)
+
+			w := httptest.NewRecorder()
+			api.ServeHTTP(w, req)
+
+			f := func(w *httptest.ResponseRecorder) bool {
+				if w.Code != tt.expectedCode {
+					t.Errorf("expected status code %d, got %d", tt.expectedCode, w.Code)
+					// ステータスが異なる場合は以降の比較を行わない
+					return false
+				}
+
+				var actualBody []map[string]interface{}
+				if err := json.Unmarshal(w.Body.Bytes(), &actualBody); err != nil {
+					t.Errorf("failed to unmarshal response body: %v", err)
+					return false
+				}
+				if diff := cmp.Diff(tt.expectedBody, actualBody); diff != "" {
+					t.Errorf("response body mismatch (-want +got):\n%s", diff)
+				}
+
+				return true
+			}
+
+			if !f(w) {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestProduct_PostProducts(t *testing.T) {
+	tests := map[string]struct {
+		requestBody  map[string]any
+		expectedCode int
+		expectedBody []map[string]any
+	}{
+		"正常系": {
+			requestBody: map[string]any{
+				"owner_id":    "01HCNYK3F7RJTWJ7GAQHPZDVE3",
+				"name":        "サウナハット2",
+				"description": "今治タオルを素材としたこだわりのサウナハット",
+				"price":       3000,
+				"stock":       2,
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: []map[string]any{
+				{
+					"description": "",
+					"id":          "01HCNYK4MQNC6G6X3F3DGXZ2J8",
+					"name":        "サウナハット",
+					"price":       float64(3000),
+					"stock":       float64(20),
+					"owner_id":    "01HCNYK3F7RJTWJ7GAQHPZDVE3",
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			resetTestData(t)
+			b, err := json.Marshal(tt.requestBody)
+			if err != nil {
+				t.Errorf("failed to marshal err: %v", err)
+				t.Fail()
+			}
+			req := httptest.NewRequest(http.MethodPost, "/v1/products", bytes.NewBuffer(b))
 
 			w := httptest.NewRecorder()
 			api.ServeHTTP(w, req)

--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -75,7 +75,7 @@ func TestProduct_PostProducts(t *testing.T) {
 				"price":       3000,
 				"stock":       2,
 			},
-			expectedCode: http.StatusOK,
+			expectedCode: http.StatusCreated,
 			expectedBody: []map[string]any{
 				{
 					"description": "",

--- a/app/server/api_test/product_test.go
+++ b/app/server/api_test/product_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/oklog/ulid/v2"
 	"github.com/sebdah/goldie/v2"
 )
@@ -80,12 +81,11 @@ func TestProduct_PostProducts(t *testing.T) {
 			expectedBody: map[string]any{
 				"product": map[string]any{
 					"description": "今治タオルを素材としたこだわりのサウナハット",
-					// IDはランダムな文字列なため、Diffでは比較しない
-					// "id":          "01HCNYK3F7RJTWJ7GAQHPZDVE3",
-					"name":     "サウナハット青",
-					"price":    float64(3000),
-					"stock":    float64(2),
-					"owner_id": "01HCNYK3F7RJTWJ7GAQHPZDVE3",
+					"id":          "01HCNYK3F7RJTWJ7GAQHPZDVE3",
+					"name":        "サウナハット青",
+					"price":       float64(3000),
+					"stock":       float64(2),
+					"owner_id":    "01HCNYK3F7RJTWJ7GAQHPZDVE3",
 				},
 			},
 		},
@@ -111,17 +111,22 @@ func TestProduct_PostProducts(t *testing.T) {
 			if err := json.Unmarshal(w.Body.Bytes(), &actualBody); err != nil {
 				t.Fatalf("failed to unmarshal response body: %v", err)
 			}
+
 			product, ok := actualBody["product"].(map[string]any)
 			if !ok {
 				t.Fatalf("failed to parse response body: %v", actualBody)
 			}
-			// ULIDはランダムな文字列なため、形式のみチェック
+			// ULIDの形式をチェック
 			if _, err := ulid.ParseStrict(product["id"].(string)); err != nil {
 				t.Errorf("id is not a valid ULID: %v", product["id"])
 			}
-			// IDはランダムな文字列なため、Diffでは比較しない
-			delete(actualBody["product"].(map[string]any), "id")
-			if diff := cmp.Diff(tt.expectedBody, actualBody); diff != "" {
+
+			opts := []cmp.Option{
+				cmpopts.IgnoreMapEntries(func(key string, value any) bool {
+					return key == "id"
+				}),
+			}
+			if diff := cmp.Diff(tt.expectedBody, actualBody, opts...); diff != "" {
 				t.Errorf("response body mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
# 内容
POSTのテスト例として、ProductPostsのIntegrationテストを追加した

# エビデンス

テスト

```
$ make test-integration
cd app && go vet ./...
go test ./app/server/api_test...
ok      github/code-kakitai/code-kakitai/server/api_test
```

# 備考

下記のPRでmain_test.goにてDBがnil pointerになるエラーを解消させています
https://github.com/code-kakitai/code-kakitai/pull/105