### PR TITLE
READMEに記載されていたswaggerのポート番号を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ swagger-up:
 	docker-compose -f app/docs/swagger/docker-compose.yml up -d
 	open http://localhost:8002
 
+swagger-stop:
+	docker-compose -f app/docs/swagger/docker-compose.yml stop
+
 ##################
 ##### DB関連 #####
 ##################

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ gen-swagger:
 
 swagger-up:
 	docker-compose -f app/docs/swagger/docker-compose.yml up -d
+	open http://localhost:8002
 
 ##################
 ##### DB関連 #####

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make run
 make swagger-up
 ```
 こちらのコマンドで、Swaggerのコンテナが起動します。
-localhost:8080にて確認可能です。
+localhost:8002にて確認可能です。
 
 ## 著者
 - [hiroaki](https://twitter.com/hiroaki_u329)


### PR DESCRIPTION
## 内容

READMEに記載されていた、Swaggerのポート番号を修正
8080→8002

## エビデンス

<img width="1493" alt="スクリーンショット 2024-03-27 0 47 55" src="https://github.com/code-kakitai/code-kakitai/assets/52862370/8ed4834c-b01f-45c0-8235-9552e37d482d">
