### PR TITLE
ビルドタグ名をparallleとserialに変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ test: lint
 test-integration: lint test-integration-read test-integration-write
 
 test-integration-read: lint
-	go test ./app/server/api_test/api_read_test... -tags integration_read
+	go test ./app/server/api_test/api_read_test... -tags parallel
 
 test-integration-write: lint
-	go test ./app/server/api_test/api_write_test... -tags integration_write
+	go test ./app/server/api_test/api_write_test... -tags serial
 
 lint:
 	cd app && go vet ./...

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://techbookfest.org/product/9a3U54LBdKDE30ewPS6Ugn)は、Go言語を使用�
 
 ```json
   "go.toolsEnvVars": {
-    "GOFLAGS": "-tags=integration_read,integration_write"
+    "GOFLAGS": "-tags=parallel,serial"
   },
 ```
 

--- a/app/server/api_test/api_read_test/main_test.go
+++ b/app/server/api_test/api_read_test/main_test.go
@@ -1,4 +1,4 @@
-//go:build integration_read
+//go:build parallel
 
 package api_read_test
 

--- a/app/server/api_test/api_read_test/product_test.go
+++ b/app/server/api_test/api_read_test/product_test.go
@@ -1,4 +1,4 @@
-//go:build integration_read
+//go:build parallel
 
 package api_read_test
 

--- a/app/server/api_test/api_read_test/user_test.go
+++ b/app/server/api_test/api_read_test/user_test.go
@@ -1,4 +1,4 @@
-//go:build integration_read
+//go:build parallel
 
 package api_read_test
 

--- a/app/server/api_test/api_write_test/cart_test.go
+++ b/app/server/api_test/api_write_test/cart_test.go
@@ -1,4 +1,4 @@
-//go:build integration_write
+//go:build serial
 
 package api_write_test
 

--- a/app/server/api_test/api_write_test/main_test.go
+++ b/app/server/api_test/api_write_test/main_test.go
@@ -1,4 +1,4 @@
-//go:build integration_write
+//go:build serial
 
 package api_write_test
 

--- a/app/server/api_test/api_write_test/order_test.go
+++ b/app/server/api_test/api_write_test/order_test.go
@@ -1,4 +1,4 @@
-//go:build integration_write
+//go:build serial
 
 package api_write_test
 

--- a/app/server/api_test/api_write_test/product_test.go
+++ b/app/server/api_test/api_write_test/product_test.go
@@ -1,4 +1,4 @@
-//go:build integration_write
+//go:build serial
 
 package api_write_test
 


### PR DESCRIPTION
## 内容
並列と直列が伝わるビルドタグ名に更新した

## エビデンス
テスト

```
$ go test ./app/server/api_test/api_read_test... -tags parallel
ok      github/code-kakitai/code-kakitai/server/api_test/api_read_test  (cached)

$ go test ./app/server/api_test/api_write_test... -tags serial
ok      github/code-kakitai/code-kakitai/server/api_test/api_write_test (cached)
```


<img width="448" alt="スクリーンショット 2024-04-14 14 59 05" src="https://github.com/code-kakitai/code-kakitai/assets/52862370/7cd42e5c-693d-4820-a87a-1b1244a3c38b">

## 備考
domainディレクトリなどはmockしているため、書き込み処理もt.parallel()でテストできる。これを考慮すると、readとwriteでは分割しづらいため、parallelとserialに命名を変更した。